### PR TITLE
Fix duplicate style tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,7 +57,6 @@
         async='async'></script>
 
     <style>
-   <style>
         body {
             font-family: "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
             line-height: 1.6;


### PR DESCRIPTION
## Summary
- remove extra `<style>` tag in the default layout

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
class MyParser(HTMLParser):
    def error(self, message):
        print('error', message)
html=open('_layouts/default.html').read()
parser=MyParser()
parser.feed(html)
print('errors:', getattr(parser, 'errors', []))
PY
`