### PR TITLE
Switch to Bootstrap 5 and drop jQuery

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,12 +3,12 @@
 
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="follow_it-verification-code" content="DumQfZmfXJN5jtC7tGkt" />
     {% feed_meta %}
 
     <!-- Styling and Visuals -->
-    <link rel="stylesheet" href="/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-VOr8O2j+d5uQ4Os+NiMbwL0uOqHZmreod5d2R+q9nRltWJih+0TO1oew4uA8dEJ1" crossorigin="anonymous" />
     <link rel="stylesheet" href="/css/monokai.css" />
     <link rel="stylesheet" href="/css/typography.css" />
 
@@ -120,12 +120,12 @@
     <div class="container">
         <nav class="navbar navbar-expand-lg navbar-dark">
             <a class="navbar-brand" href="/">Joshua Cole</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav ml-auto">
+                <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="/">Home</a>
                     </li>
@@ -140,9 +140,7 @@
         {{ content }}
     </div>
 
-    <script type="text/javascript" src="/js/jquery-3.3.1.slim.min.js"></script>
-    <script type="text/javascript" src="/js/popper.min.js"></script>
-    <script type="text/javascript" src="/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-wCv2zuwfK9bZrvfyEiqZISQ2ZBkoU+B5gM0I5FOI02D500BjbiEXeZivnOPlIr66" crossorigin="anonymous"></script>
     <script type="text/javascript" src="/js/d3.5.9.1.min.js"></script>
     <script type="text/javascript" src="/js/underscore.js"></script>
     <script type="text/javascript" src="/js/visualization.js"></script>


### PR DESCRIPTION
## Summary
- update layout to load Bootstrap 5 from CDN
- remove jQuery and old Popper
- adjust markup for Bootstrap 5

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `bundle install` *(fails due to 403 Forbidden / no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6854a24f1c048328be2ea04a38ed94eb