### PR TITLE
Fix layout regression and extract styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,9 @@
     <!-- Styling and Visuals -->
     <link rel="stylesheet" href="/css/bootstrap.min.css" />
     <link rel="stylesheet" href="/css/monokai.css" />
+
     <link rel="stylesheet" href="/css/typography.css" />
+    <link rel="stylesheet" href="/css/site.css" />
 
     <script>
         window.d3VizInits = [];
@@ -55,65 +57,6 @@
         src='https://platform-api.sharethis.com/js/sharethis.js#property=6035bcacf860700011e71dd5&product=inline-share-buttons'
         async='async'></script>
 
-    <style>
-        body {
-            font-family: "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
-            line-height: 1.6;
-            margin: 0;
-            padding: 0;
-            background-color: #fdfdfd;
-            color: #111;
-        }
-        .navbar {
-            background-color: #333;
-            padding: 10px 20px;
-        }
-        .navbar-brand, .navbar-nav .nav-link {
-            color: #fff !important;
-            font-size: 18px;
-        }
-        .navbar-nav .nav-link {
-            margin-right: 15px;
-            padding: 10px 15px;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .navbar-nav .nav-link:hover {
-            background-color: #555;
-            color: #fff;
-        }
-        .container {
-            margin-top: 20px;
-        }
-        .about-me {
-            padding: 20px;
-            background-color: #f9f9f9;
-            border-radius: 5px;
-        }
-        .writing-section {
-            margin-top: 40px;
-        }
-        .writing-post {
-            margin-bottom: 20px;
-            padding: 15px;
-            border: 1px solid #ddd;
-            border-radius: 5px;
-            background-color: #fff;
-        }
-        .writing-post strong {
-            display: block;
-            font-size: 1.2em;
-            margin-bottom: 5px;
-        }
-        footer {
-            background-color: #333;
-            color: #fff;
-            padding: 10px 0;
-            text-align: center;
-        }
-        footer a {
-            color: #fff;
-        }
-    </style>
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/css/site.css
+++ b/css/site.css
@@ -1,0 +1,57 @@
+body {
+    font-family: "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #fdfdfd;
+    color: #111;
+}
+.navbar {
+    background-color: #333;
+    padding: 10px 20px;
+}
+.navbar-brand, .navbar-nav .nav-link {
+    color: #fff !important;
+    font-size: 18px;
+}
+.navbar-nav .nav-link {
+    margin-right: 15px;
+    padding: 10px 15px;
+    transition: background-color 0.3s, color 0.3s;
+}
+.navbar-nav .nav-link:hover {
+    background-color: #555;
+    color: #fff;
+}
+.container {
+    margin-top: 20px;
+}
+.about-me {
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 5px;
+}
+.writing-section {
+    margin-top: 40px;
+}
+.writing-post {
+    margin-bottom: 20px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background-color: #fff;
+}
+.writing-post strong {
+    display: block;
+    font-size: 1.2em;
+    margin-bottom: 5px;
+}
+footer {
+    background-color: #333;
+    color: #fff;
+    padding: 10px 0;
+    text-align: center;
+}
+footer a {
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- restore missing layout markup
- move inline styles to `css/site.css`
- link the external stylesheet from `default.html`

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854a27de768832880462b079c5acf52