### PR TITLE
Remove integrity attribute from CSS and JS links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     {% feed_meta %}
 
     <!-- Styling and Visuals -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-VOr8O2j+d5uQ4Os+NiMbwL0uOqHZmreod5d2R+q9nRltWJih+0TO1oew4uA8dEJ1" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" crossorigin="anonymous" />
     <link rel="stylesheet" href="/css/monokai.css" />
 
     <link rel="stylesheet" href="/css/typography.css" />
@@ -83,7 +83,7 @@
         {{ content }}
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-wCv2zuwfK9bZrvfyEiqZISQ2ZBkoU+B5gM0I5FOI02D500BjbiEXeZivnOPlIr66" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
     <script type="text/javascript" src="/js/d3.5.9.1.min.js"></script>
     <script type="text/javascript" src="/js/underscore.js"></script>
     <script type="text/javascript" src="/js/visualization.js"></script>


### PR DESCRIPTION
## Summary
- remove SRI integrity attribute from Bootstrap CSS and JS links in the default layout

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854a80b4fa08328b54f07a5c0412972