### PR TITLE
Fix visualization init without jQuery

### DIFF
--- a/js/visualization.js
+++ b/js/visualization.js
@@ -234,6 +234,6 @@ function numberLineControlledLineChart(selection) {
 }
 
 
-$(document).ready(function() {
+document.addEventListener('DOMContentLoaded', function() {
   window.d3VizInits.forEach(function(viz) { viz(); });
 });


### PR DESCRIPTION
## Summary
- rework visualization.js to initialize on DOMContentLoaded instead of jQuery

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854b1bd3a288328acb4a4b7eeb3cf18