### PR TITLE
Restore jQuery dependency

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,6 +83,7 @@
         {{ content }}
     </div>
 
+    <script type="text/javascript" src="/js/jquery-3.3.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
     <script type="text/javascript" src="/js/d3.5.9.1.min.js"></script>
     <script type="text/javascript" src="/js/underscore.js"></script>

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -234,6 +234,6 @@ function numberLineControlledLineChart(selection) {
 }
 
 
-document.addEventListener('DOMContentLoaded', function() {
+$(document).ready(function() {
   window.d3VizInits.forEach(function(viz) { viz(); });
 });


### PR DESCRIPTION
## Summary
- reintroduce jQuery in default layout
- revert visualization initialization to jQuery `$(document).ready`

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6854b50fba688328b6de7d361a2aaa9d