### PR TITLE
Simplify homepage and add dedicated pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,6 +73,15 @@
                         <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/writing.html">Writing</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/projects.html">Projects</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/links.html">Links</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/meta.html">Meta</a>
                     </li>
                 </ul>

--- a/index.md
+++ b/index.md
@@ -6,57 +6,20 @@ layout: default
 <div class="about-me">
   <h2>About Me</h2>
   <p>
-    I'm a generalist Software Engineer, AI & Machine Learning Expert, and CEO of TackTech, an AI startup providing <a href="https://tacktech.ai">personalized AI</a>.
+    I'm the CEO, lead engineer, and research scientist at TackTech where I'm working at democratizing optimal strategic reasoning. I'm also a Principal Software Engineer at Walmart.
   </p>
   <p>
-    I spend most of my time thinking about software engineering, artificial intelligence, game theory, and machine learning problems.  I sometimes write about my thoughts on this blog.  Often I do it to avoid repeating myself.  
+    I love hard engineering problems, learning learning, understanding understanding, and thinking about thinking. Previously I worked at Amazon on an Alexa feature experiment platform and before that I worked at Meta doing at scale machine learning on <a href="https://www.facebook.com/business/tools/meta-pixel">pixel data</a>.
   </p>
   <p>
-    I also enjoy writing and competitive gaming in my spare time.
+    I also love making excellent products. I served as technical lead on a cloud-based platform that won a <strong>CI BEST Award</strong> at <a href="https://www.commercialintegrator.com/news/pakedge_unleashes_bakpak_30_cloud_management/"><em>InfoComm 2015</em></a>, the largest pro-AV and systems-integration show in North America. I helped keep Pakedge at the top of the <a href="https://www.cepro.com/network/ce-pro-2018-brand-analysis-home-networking/"><strong>CE Pro Brand Leader</strong></a> list in Home Networking for multiple consecutive years, including 2017 and 2018, when Pakedge led the category among CE Pro 100 integrators.
   </p>
 </div>
 
-<div class="writing-section">
-<h2>Writing</h2>
-
-{% for post in site.posts %}
-<div class="writing-post">
-  <strong>{{ post.date | date: "%B %d, %Y" }}:</strong> <a href="{{ post.url }}">{{ post.title }}</a><br>
-  {{ post.content | strip_html | truncatewords: 50 }}
-</div>
-{% endfor %}
-</div>
-
-## Tools
-
-Some minor tools I've made and made publicly available. Nothing special here.
-
- - [SVG To D3.js Compiler](/svg2d3.html)
-
-## Elsewhere On The Internet
-
-In addition to the content I host here on my own domain, I also have works on other websites. If you would like to support my online presence or see other content by me, please follow me on these other platforms.
-
-- [TackTech](https://tacktech.ai/)
-
-- [Patreon](https://www.patreon.com/toojoshua)
-
-- [Twitch](https://www.twitch.tv/toojoshua)
-
-- [YouTube](https://youtube.com/jcolechanged)
-
-- [fanfiction.net](https://www.fanfiction.net/~toojoshua)
-
-- [SpaceBattles](https://forums.spacebattles.com/members/toojoshua.315351/)
-
-- [Twitter](https://www.twitter.com/combinatoricole)
-
-- [Quora](https://www.quora.com/profile/Joshua-Cole-185)
-
-- [Reddit](https://www.reddit.com/u/jcolechanged)
-
-- [Hacker News](https://news.ycombinator.com/user?id=JoshCole)
-
-- [GitHub](https://www.github.com/jcolechanged)
+<ul>
+  <li><a href="/writing.html">Writing</a></li>
+  <li><a href="/projects.html">Projects</a></li>
+  <li><a href="/links.html">Elsewhere on the Internet</a></li>
+</ul>
 
 {% include notifications.html %}

--- a/links.md
+++ b/links.md
@@ -1,0 +1,30 @@
+---
+title: Links
+layout: default
+---
+
+## Elsewhere On The Internet
+
+In addition to the content I host here on my own domain, I also have works on other websites. If you would like to support my online presence or see other content by me, please follow me on these other platforms.
+
+- [TackTech](https://tacktech.ai/)
+
+- [Patreon](https://www.patreon.com/toojoshua)
+
+- [Twitch](https://www.twitch.tv/toojoshua)
+
+- [YouTube](https://youtube.com/jcolechanged)
+
+- [fanfiction.net](https://www.fanfiction.net/~toojoshua)
+
+- [SpaceBattles](https://forums.spacebattles.com/members/toojoshua.315351/)
+
+- [Twitter](https://www.twitter.com/combinatoricole)
+
+- [Quora](https://www.quora.com/profile/Joshua-Cole-185)
+
+- [Reddit](https://www.reddit.com/u/jcolechanged)
+
+- [Hacker News](https://news.ycombinator.com/user?id=JoshCole)
+
+- [GitHub](https://www.github.com/jcolechanged)

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,10 @@
+---
+title: Projects
+layout: default
+---
+
+## Projects
+
+Some minor tools I've made and made publicly available. Nothing special here.
+
+- [SVG To D3.js Compiler](/svg2d3.html)

--- a/writing.md
+++ b/writing.md
@@ -1,0 +1,15 @@
+---
+title: Writing
+layout: default
+---
+
+<div class="writing-section">
+<h2>Writing</h2>
+
+{% for post in site.posts %}
+<div class="writing-post">
+  <strong>{{ post.date | date: "%B %d, %Y" }}:</strong> <a href="{{ post.url }}">{{ post.title }}</a><br>
+  {{ post.content | strip_html | truncatewords: 50 }}
+</div>
+{% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- Clean home page by trimming writing and project sections and linking to dedicated pages
- Add separate pages for writing posts, projects, and external links
- Update site navigation with links to the new pages
- Refresh "About Me" content with updated bio

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*


------
https://chatgpt.com/codex/tasks/task_e_68958a6b335c8328a20d9e7c62b56446